### PR TITLE
Blocs refactor

### DIFF
--- a/lib/blocs/alarm-channel-bloc.dart
+++ b/lib/blocs/alarm-channel-bloc.dart
@@ -57,6 +57,25 @@ class AlarmChannelBloc {
     return _currentUserVote!;
   }
 
+  /// Stream of the alarm options in this alarm channel.
+  Stream<List<AlarmOption>>? _alarmOptions;
+
+  /// Lazy getter for the stream of alarm options.
+  Stream<List<AlarmOption>> get alarmOptions {
+    if (_alarmOptions == null) {
+      _alarmOptions = FirebaseFirestore.instance
+          .collection("/$CHANNELS_COLLECTION/$channelId/$OPTIONS_SUB")
+          .orderBy(TIME_FIELD)
+          .snapshots()
+          .map((QuerySnapshot snapshot) => snapshot.docs)
+          .map((List<QueryDocumentSnapshot> docs) {
+        return docs.map((QueryDocumentSnapshot docSnap) =>
+            AlarmOption(docSnap.data()[TIME_FIELD], docSnap.data()[VOTES_FIELD] ?? 0));
+      })
+          .map((Iterable<AlarmOption> alarmOptions) => alarmOptions.toList());
+    }
+    return _alarmOptions!;
+  }
 
   /// Adds a user with targetUsername to an alarm channel.
   Future<bool> addUserToChannel(String targetUsername, AlarmChannel alarmChannel) async {

--- a/lib/blocs/alarm-channel-bloc.dart
+++ b/lib/blocs/alarm-channel-bloc.dart
@@ -10,13 +10,13 @@ import 'package:wake_together/data/models/alarm-channel.dart';
 
 class AlarmChannelBloc {
 
-  AlarmChannelBloc(this.alarmChannelOverview) {
+  AlarmChannelBloc(this.alarmChannel) {
     init();
-    channelId = this.alarmChannelOverview.channelId;
+    channelId = this.alarmChannel.channelId;
   }
 
-  /// AlarmChannelOverview tied to this bloc.
-  final AlarmChannelOverview alarmChannelOverview;
+  /// AlarmChannel tied to this bloc.
+  final AlarmChannel alarmChannel;
 
   /// Channel ID of the alarm tied to this bloc.
   late final String channelId;
@@ -131,7 +131,7 @@ class AlarmChannelBloc {
         .set({
       CHANNEL_ID_FIELD: channelId,
       CHANNEL_NAME_FIELD: await _channelName.last,
-      CURRENT_ALARM_FIELD: alarmChannelOverview.currentAlarm,
+      CURRENT_ALARM_FIELD: alarmChannel.currentAlarm,
     });
 
     return true;
@@ -251,7 +251,7 @@ class AlarmChannelBloc {
   /// Opts the user out of the current vote.
   void optOut() async {
     await FirebaseFirestore.instance
-        .doc(("/$CHANNELS_COLLECTION/${alarmChannelOverview.channelId}/$VOTES_SUB/$userId"))
+        .doc(("/$CHANNELS_COLLECTION/${alarmChannel.channelId}/$VOTES_SUB/$userId"))
         .delete();
 
     // Register opt out under the user

--- a/lib/blocs/alarm-channel-bloc.dart
+++ b/lib/blocs/alarm-channel-bloc.dart
@@ -43,7 +43,19 @@ class AlarmChannelBloc {
     return _subscribers!;
   }
 
+  /// Stream of the current user's vote for this alarm channel.
+  Stream<Timestamp?>? _currentUserVote;
 
+  /// Lazy getter for the stream of user's current vote.
+  Stream<Timestamp?> get currentUserVote {
+    if (_currentUserVote == null) {
+      _currentUserVote = FirebaseFirestore.instance
+          .doc("/$CHANNELS_COLLECTION/$channelId/$VOTES_SUB/$userId")
+          .snapshots()
+          .map((DocumentSnapshot docSnap) => docSnap.data()?[TIME_FIELD]);
+    }
+    return _currentUserVote!;
+  }
 
 
   /// Adds a user with targetUsername to an alarm channel.

--- a/lib/blocs/alarm-channel-bloc.dart
+++ b/lib/blocs/alarm-channel-bloc.dart
@@ -25,6 +25,27 @@ class AlarmChannelBloc {
     await Firebase.initializeApp();
   }
 
+  /// Stream of subscribers for this alarm channel.
+  Stream<List<String?>>? _subscribers;
+
+  /// Lazy getter for the stream of subscribers.
+  Stream<List<String?>> get subscribers {
+    if (_subscribers == null) {
+      _subscribers = FirebaseFirestore.instance
+          .collection("/$CHANNELS_COLLECTION/$channelId/$SUBSCRIBERS_SUB")
+          .snapshots()
+          .map((QuerySnapshot snapshot) => snapshot.docs)
+          .map((List<QueryDocumentSnapshot> docSnapshots) {
+        return docSnapshots.map((QueryDocumentSnapshot docSnapshot) =>
+        docSnapshot.data()[USERNAME_FIELD] as String?).toList();
+      });
+    }
+    return _subscribers!;
+  }
+
+
+
+
   /// Adds a user with targetUsername to an alarm channel.
   Future<bool> addUserToChannel(String targetUsername, AlarmChannel alarmChannel) async {
 

--- a/lib/blocs/shared-alarms-bloc.dart
+++ b/lib/blocs/shared-alarms-bloc.dart
@@ -127,24 +127,8 @@ class SharedAlarmsBloc {
         .map((DocumentSnapshot docSnap) => AlarmChannel(
             channelId,
             docSnap.data()?[CHANNEL_NAME_FIELD],
-            docSnap.data()?[OWNER_ID_FIELD],
-            _getAlarmChannelOptions(channelId))
+            docSnap.data()?[OWNER_ID_FIELD])
     );
-  }
-
-  /// Returns a stream providing the alarm options for the alarm channel
-  /// with channelId.
-  Stream<List<AlarmOption>> _getAlarmChannelOptions(String channelId) {
-    return FirebaseFirestore.instance
-        .collection("/$CHANNELS_COLLECTION/$channelId/$OPTIONS_SUB")
-        .orderBy(TIME_FIELD)
-        .snapshots()
-        .map((QuerySnapshot snapshot) => snapshot.docs)
-        .map((List<QueryDocumentSnapshot> docs) {
-      return docs.map((QueryDocumentSnapshot docSnap) =>
-          AlarmOption(docSnap.data()[TIME_FIELD], docSnap.data()[VOTES_FIELD] ?? 0));
-    })
-        .map((Iterable<AlarmOption> alarmOptions) => alarmOptions.toList());
   }
 
   /// Creates a new alarm channel with a name.

--- a/lib/blocs/shared-alarms-bloc.dart
+++ b/lib/blocs/shared-alarms-bloc.dart
@@ -128,7 +128,6 @@ class SharedAlarmsBloc {
             channelId,
             docSnap.data()?[CHANNEL_NAME_FIELD],
             docSnap.data()?[OWNER_ID_FIELD],
-            _getAlarmChannelSubscribers(channelId),
             _getAlarmChannelOptions(channelId),
             _getAlarmChannelCurrentVote(channelId))
     );
@@ -156,17 +155,6 @@ class SharedAlarmsBloc {
           AlarmOption(docSnap.data()[TIME_FIELD], docSnap.data()[VOTES_FIELD] ?? 0));
     })
         .map((Iterable<AlarmOption> alarmOptions) => alarmOptions.toList());
-  }
-
-  Stream<List<String?>> _getAlarmChannelSubscribers(String channelId) {
-    return FirebaseFirestore.instance
-        .collection("/$CHANNELS_COLLECTION/$channelId/$SUBSCRIBERS_SUB")
-        .snapshots()
-        .map((QuerySnapshot snapshot) => snapshot.docs)
-        .map((List<QueryDocumentSnapshot> docSnapshots) {
-      return docSnapshots.map((QueryDocumentSnapshot docSnapshot) =>
-      docSnapshot.data()[USERNAME_FIELD] as String?).toList();
-    });
   }
 
   /// Creates a new alarm channel with a name.

--- a/lib/blocs/shared-alarms-bloc.dart
+++ b/lib/blocs/shared-alarms-bloc.dart
@@ -111,23 +111,10 @@ class SharedAlarmsBloc {
   AlarmChannelOverview _alarmChannelOverviewFrom(
       QueryDocumentSnapshot docSnap) {
     return AlarmChannelOverview(
-        docSnap.data()[CHANNEL_NAME_FIELD],
-        _getAlarmChannel(docSnap.id),
-        docSnap.id,
-        docSnap.data()[CURRENT_ALARM_FIELD],
-        docSnap.data()[HAS_VOTED_FIELD] ?? false);
-  }
-
-  /// Returns a Future that provides the AlarmChannel representing the alarm
-  /// channel with channelId in /channels/.
-  Future<Stream<AlarmChannel>> _getAlarmChannel(String channelId) async {
-    return FirebaseFirestore.instance
-        .doc("/$CHANNELS_COLLECTION/$channelId")
-        .snapshots()
-        .map((DocumentSnapshot docSnap) => AlarmChannel(
-            channelId,
-            docSnap.data()?[CHANNEL_NAME_FIELD],
-            docSnap.data()?[OWNER_ID_FIELD])
+        channelName: docSnap.data()[CHANNEL_NAME_FIELD],
+        channelId: docSnap.id,
+        currentAlarmTimestamp: docSnap.data()[CURRENT_ALARM_FIELD],
+        isActivated: docSnap.data()[HAS_VOTED_FIELD] ?? false,
     );
   }
 

--- a/lib/blocs/shared-alarms-bloc.dart
+++ b/lib/blocs/shared-alarms-bloc.dart
@@ -128,18 +128,8 @@ class SharedAlarmsBloc {
             channelId,
             docSnap.data()?[CHANNEL_NAME_FIELD],
             docSnap.data()?[OWNER_ID_FIELD],
-            _getAlarmChannelOptions(channelId),
-            _getAlarmChannelCurrentVote(channelId))
+            _getAlarmChannelOptions(channelId))
     );
-  }
-
-  /// Returns a stream providing the current user vote for the alarm
-  /// channel with channelId.
-  Stream<Timestamp?> _getAlarmChannelCurrentVote(String channelId) {
-    return FirebaseFirestore.instance
-        .doc("/$CHANNELS_COLLECTION/$channelId/$VOTES_SUB/$userId")
-        .snapshots()
-        .map((DocumentSnapshot docSnap) => docSnap.data()?[TIME_FIELD]);
   }
 
   /// Returns a stream providing the alarm options for the alarm channel

--- a/lib/blocs/shared-alarms-bloc.dart
+++ b/lib/blocs/shared-alarms-bloc.dart
@@ -89,16 +89,16 @@ class SharedAlarmsBloc {
   }
 
   /// Stream for channels to listen for realtime changes.
-  Stream<List<AlarmChannelOverview>>? _subscribedChannels;
+  Stream<List<AlarmChannel>>? _subscribedChannels;
 
   /// Getter for _subscribedChannels with lazy evaluation.
-  Stream<List<AlarmChannelOverview>> get subscribedChannels {
+  Stream<List<AlarmChannel>> get subscribedChannels {
     if (_subscribedChannels == null) {
       _subscribedChannels = FirebaseFirestore.instance
           .collection(subscribedChannelsPath)
           .snapshots()
           .map((QuerySnapshot snapshot) =>
-          snapshot.docs.map(_alarmChannelOverviewFrom).toList())
+          snapshot.docs.map(_alarmChannelFrom).toList())
           .asBroadcastStream();
 
       _subscribedChannels!.listen(registerSharedAlarms);
@@ -107,10 +107,10 @@ class SharedAlarmsBloc {
   }
 
   /// Maps a QueryDocumentSnapshot from /user/.../subscribed_channels/ to
-  /// an AlarmChannelOverview.
-  AlarmChannelOverview _alarmChannelOverviewFrom(
+  /// an AlarmChannel.
+  AlarmChannel _alarmChannelFrom(
       QueryDocumentSnapshot docSnap) {
-    return AlarmChannelOverview(
+    return AlarmChannel(
         channelName: docSnap.data()[CHANNEL_NAME_FIELD],
         channelId: docSnap.id,
         currentAlarmTimestamp: docSnap.data()[CURRENT_ALARM_FIELD],
@@ -169,8 +169,8 @@ class SharedAlarmsBloc {
     }
   }
 
-  void registerSharedAlarms(List<AlarmChannelOverview> channels) async {
-    for (AlarmChannelOverview channel in channels) {
+  void registerSharedAlarms(List<AlarmChannel> channels) async {
+    for (AlarmChannel channel in channels) {
       if (channel.isActivated) {
         registerAlarmChannel(context, channel);
       }

--- a/lib/data/alarm-helper.dart
+++ b/lib/data/alarm-helper.dart
@@ -61,8 +61,8 @@ void _registerAlarm(BuildContext context, Alarm alarm) async {
   }
 }
 
-/// Registers an Alarm Channel alarm through its overview.
-void registerAlarmChannel(BuildContext context, AlarmChannelOverview channel) {
+/// Registers an alarm channel alarm.
+void registerAlarmChannel(BuildContext context, AlarmChannel channel) {
   if (!channel.isActivated) {
     return;
   }
@@ -75,7 +75,7 @@ void registerAlarmChannel(BuildContext context, AlarmChannelOverview channel) {
     return;
   }
 
-  // Construct an Alarm object using data from the overview.
+  // Construct an Alarm object using data from the AlarmChannel.
   Alarm alarm = Alarm(
       id: 0,
       description: channel.channelName ?? "",

--- a/lib/data/models/alarm-channel.dart
+++ b/lib/data/models/alarm-channel.dart
@@ -32,7 +32,7 @@ class AlarmChannelOverview {
 
 /// Stores the detailed information of each alarm channel.
 class AlarmChannel {
-  AlarmChannel(this.channelId, this.channelName, this.ownerId, this.subscribers,
+  AlarmChannel(this.channelId, this.channelName, this.ownerId,
       this.alarmOptions, this.currentVote);
 
   /// Name of the alarm channel.
@@ -43,9 +43,6 @@ class AlarmChannel {
 
   /// User id for the owner (creator) of this alarm channel.
   final String? ownerId;
-
-  /// List of subscriber name of this alarm channel.
-  final Stream<List<String?>> subscribers;
 
   /// List of alarm options for voting.
   final Stream<List<AlarmOption>> alarmOptions;

--- a/lib/data/models/alarm-channel.dart
+++ b/lib/data/models/alarm-channel.dart
@@ -33,7 +33,7 @@ class AlarmChannelOverview {
 /// Stores the detailed information of each alarm channel.
 class AlarmChannel {
   AlarmChannel(this.channelId, this.channelName, this.ownerId,
-      this.alarmOptions, this.currentVote);
+      this.alarmOptions);
 
   /// Name of the alarm channel.
   final String? channelName;
@@ -46,9 +46,6 @@ class AlarmChannel {
 
   /// List of alarm options for voting.
   final Stream<List<AlarmOption>> alarmOptions;
-
-  /// The current user's alarm option vote.
-  final Stream<Timestamp?> currentVote;
 }
 
 /// A single voting option in AlarmChannel.

--- a/lib/data/models/alarm-channel.dart
+++ b/lib/data/models/alarm-channel.dart
@@ -32,8 +32,7 @@ class AlarmChannelOverview {
 
 /// Stores the detailed information of each alarm channel.
 class AlarmChannel {
-  AlarmChannel(this.channelId, this.channelName, this.ownerId,
-      this.alarmOptions);
+  AlarmChannel(this.channelId, this.channelName, this.ownerId);
 
   /// Name of the alarm channel.
   final String? channelName;
@@ -43,9 +42,6 @@ class AlarmChannel {
 
   /// User id for the owner (creator) of this alarm channel.
   final String? ownerId;
-
-  /// List of alarm options for voting.
-  final Stream<List<AlarmOption>> alarmOptions;
 }
 
 /// A single voting option in AlarmChannel.

--- a/lib/data/models/alarm-channel.dart
+++ b/lib/data/models/alarm-channel.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 /// Stores the information to be displayed in each list item in the Shared
 /// Alarms page.
-class AlarmChannelOverview {
-  AlarmChannelOverview({
+class AlarmChannel {
+  AlarmChannel({
     required this.channelName,
     required this.channelId,
     required this.currentAlarmTimestamp,

--- a/lib/data/models/alarm-channel.dart
+++ b/lib/data/models/alarm-channel.dart
@@ -4,8 +4,11 @@ import 'package:flutter/material.dart';
 /// Stores the information to be displayed in each list item in the Shared
 /// Alarms page.
 class AlarmChannelOverview {
-  AlarmChannelOverview(this.channelName, this.alarmChannel, this.channelId,
-      this.currentAlarmTimestamp, this.isActivated) {
+  AlarmChannelOverview({
+    required this.channelName,
+    required this.channelId,
+    required this.currentAlarmTimestamp,
+    this.isActivated = false}) {
     this.currentAlarm = currentAlarmTimestamp == null
         ? null
         : TimeOfDay.fromDateTime(currentAlarmTimestamp!.toDate());
@@ -13,9 +16,6 @@ class AlarmChannelOverview {
 
   /// Name of the alarm channel.
   final String? channelName;
-
-  /// Future containing a Stream of the full AlarmChannel
-  final Future<Stream<AlarmChannel>> alarmChannel;
 
   /// Unique id for the alarm channel.
   final String channelId;
@@ -30,21 +30,7 @@ class AlarmChannelOverview {
   final bool isActivated;
 }
 
-/// Stores the detailed information of each alarm channel.
-class AlarmChannel {
-  AlarmChannel(this.channelId, this.channelName, this.ownerId);
-
-  /// Name of the alarm channel.
-  final String? channelName;
-
-  /// Unique id for the alarm channel.
-  final String channelId;
-
-  /// User id for the owner (creator) of this alarm channel.
-  final String? ownerId;
-}
-
-/// A single voting option in AlarmChannel.
+/// A single voting option in an alarm channel.
 class AlarmOption {
   AlarmOption(this.timestamp, this.votes) {
     dateTime = DateTime.fromMillisecondsSinceEpoch(timestamp.millisecondsSinceEpoch);

--- a/lib/pages/shared-alarms/alarm-channel-page.dart
+++ b/lib/pages/shared-alarms/alarm-channel-page.dart
@@ -22,48 +22,31 @@ class AlarmChannelPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Provider<AlarmChannelBloc>(
       create: (BuildContext context) => AlarmChannelBloc(_alarmChannelOverview),
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(_alarmChannelOverview.channelName ?? "<null>"),
-          backgroundColor: Theme.of(context).colorScheme.background,
+      child: Consumer<AlarmChannelBloc>(
+        builder: (BuildContext context, AlarmChannelBloc bloc, _) => Scaffold(
+          appBar: AppBar(
+            title: StreamBuilder(
+              stream: bloc.channelName,
+                builder: (BuildContext context, AsyncSnapshot<String> snapshot) =>
+                    Text(snapshot.data ?? "<null>")),
+            backgroundColor: Theme.of(context).colorScheme.background,
+          ),
+          body: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _SubscribersBlock(),
+                  _AlarmBlock(),
+                ],
+              ),
+            ),
         ),
-        body: FutureBuilder(
-            future: _alarmChannelOverview.alarmChannel,
-            builder: (BuildContext context,
-                AsyncSnapshot<Stream<AlarmChannel>> streamSnapshot) {
-              return !streamSnapshot.hasData
-                  ? const Center(child: const CircularProgressIndicator())
-                  : StreamBuilder(
-                      stream: streamSnapshot.data,
-                      builder: (BuildContext context,
-                          AsyncSnapshot<AlarmChannel> alarmChannelSnap) {
-                        if (!alarmChannelSnap.hasData) {
-                          return const Center(
-                              child: const CircularProgressIndicator());
-                        }
-
-                        AlarmChannel alarmChannel = alarmChannelSnap.data!;
-
-                        return SingleChildScrollView(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [
-                              _SubscribersBlock(alarmChannel),
-                              _AlarmBlock(alarmChannel),
-                            ],
-                          ),
-                        );
-                      });
-            }),
       ),
     );
   }
 }
 
 class _SubscribersBlock extends StatelessWidget {
-  const _SubscribersBlock(this._alarmChannel);
-
-  final AlarmChannel _alarmChannel;
 
   @override
   Widget build(BuildContext context) {
@@ -80,8 +63,9 @@ class _SubscribersBlock extends StatelessWidget {
           child: StreamBuilder(
               stream: bloc.subscribers,
               builder: (BuildContext context,
-                  AsyncSnapshot<List<String?>> snapshot) {
-                final List<String?>? users = snapshot.data;
+                  AsyncSnapshot<List<String?>> usersSnap) {
+
+                final List<String?>? users = usersSnap.data;
 
                 final String subscriberCount = users == null
                     ? "Subscribers"
@@ -89,73 +73,78 @@ class _SubscribersBlock extends StatelessWidget {
                         ? "1 Subscriber"
                         : "${users.length} Subscribers";
 
-                final bool isOwner = _alarmChannel.ownerId == userId;
+                return StreamBuilder(
+                  builder: (BuildContext context, AsyncSnapshot<String> ownerId) {
 
-                return ClipRRect(
-                  borderRadius: BorderRadius.circular(_cardRadius),
-                  child: Material(
-                    color: Theme.of(context).colorScheme.background,
-                    child: ExpansionTile(
-                        title: Text(subscriberCount),
-                        leading: !isOwner
-                        ? Icon(Icons.people)
-                        : InkResponse(
-                            child: Icon(Icons.person_add),
-                            onTap: () async {
-                              String? username = await showInputDialog(
-                                context: context,
-                                title: "Add subscriber",
-                                validator: (String? username) {
-                                  username = username?.trim().toLowerCase();
+                    final bool isOwner = ownerId.data == userId;
+                    return ClipRRect(
+                    borderRadius: BorderRadius.circular(_cardRadius),
+                    child: Material(
+                      color: Theme.of(context).colorScheme.background,
+                      child: ExpansionTile(
+                          title: Text(subscriberCount),
+                          leading: !isOwner
+                          ? Icon(Icons.people)
+                          : InkResponse(
+                              child: Icon(Icons.person_add),
+                              onTap: () async {
+                                String? username = await showInputDialog(
+                                  context: context,
+                                  title: "Add subscriber",
+                                  validator: (String? username) {
+                                    username = username?.trim().toLowerCase();
 
-                                  if (username == null || username.isEmpty) {
-                                    return "Username cannot be empty";
-                                  }
-                                },
-                                doneAction: "Add",
-                              );
+                                    if (username == null || username.isEmpty) {
+                                      return "Username cannot be empty";
+                                    }
+                                  },
+                                  doneAction: "Add",
+                                );
 
-                              if (username == null) return;
+                                if (username == null) return;
 
-                              bool success = await bloc.addUserToChannel(
-                                  username, _alarmChannel);
+                                bool success = await bloc.addUserToChannel(username);
 
-                              if (!success) {
-                                // Notify user if the username does not exist.
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                        content: Text("User does not exist")));
-                              }
-                            }),
-                        children: [
-                          AnimatedSwitcher(
-                              duration: Duration(milliseconds: 300),
-                              child: users == null
-                                  ? Center(
-                                      child: CircularProgressIndicator(),
-                                    )
-                                  : Container(
-                                constraints: BoxConstraints(maxHeight: 192),
-                                    child: ListView.builder(
-                                        shrinkWrap: true,
-                                        itemCount: users.length,
-                                        itemBuilder:
-                                            (BuildContext context, int position) {
-                                          return ListTile(
-                                            visualDensity: VisualDensity.comfortable,
-                                            leading: Icon(Icons.person, color: toColor(users[position]!)),
-                                            title: Text(users[position]!),
-                                            trailing: !isOwner
-                                                    ? null
-                                                    : IconButton(
-                                                        icon: Icon(Icons.delete),
-                                                        onPressed: () {},
-                                                      ),
-                                          );
-                                        }),
-                                  )),
-                        ]),
-                  ),
+                                if (!success) {
+                                  // Notify user if the username does not exist.
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                          content: Text("User does not exist")));
+                                }
+                              }),
+                          children: [
+                            AnimatedSwitcher(
+                                duration: Duration(milliseconds: 300),
+                                child: users == null
+                                    ? Center(
+                                        child: CircularProgressIndicator(),
+                                      )
+                                    : Container(
+                                  constraints: BoxConstraints(maxHeight: 192),
+                                      child: ListView.builder(
+                                          shrinkWrap: true,
+                                          itemCount: users.length,
+                                          itemBuilder:
+                                              (BuildContext context, int position) {
+                                            return ListTile(
+                                              visualDensity: VisualDensity.comfortable,
+                                              leading: Icon(
+                                                  Icons.person,
+                                                  color: toColor(users[position]!)),
+                                              title: Text(users[position] ?? "<null>"),
+                                              trailing: !isOwner
+                                                      ? null
+                                                      : IconButton(
+                                                          icon: Icon(Icons.delete),
+                                                          onPressed: () {},
+                                                        ),
+                                            );
+                                          }),
+                                    )),
+                          ]),
+                    ),
+                  );
+                  },
                 );
               }),
         ),
@@ -165,10 +154,6 @@ class _SubscribersBlock extends StatelessWidget {
 }
 
 class _AlarmBlock extends StatelessWidget {
-  const _AlarmBlock(this._alarmChannel);
-
-  final AlarmChannel _alarmChannel;
-
   @override
   Widget build(BuildContext context) {
     return Consumer<AlarmChannelBloc>(
@@ -184,68 +169,74 @@ class _AlarmBlock extends StatelessWidget {
                         AsyncSnapshot<Timestamp?> voteSnapshot) {
                       Timestamp? selection = voteSnapshot.data;
 
-                      return Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Container(
-                            padding:
-                                EdgeInsets.only(left: 16, right: 16, top: 8),
-                            alignment: Alignment.center,
-                            child: Row(
-                              children: [
-                                Expanded(
-                                  child: Container(
-                                    alignment: Alignment.center,
-                                    child: Text("Alarm",
-                                        style: Theme.of(context)
-                                            .textTheme
-                                            .headline6),
+                      return StreamBuilder(
+                        stream: bloc.ownerId,
+                        builder: (BuildContext context, AsyncSnapshot<String> ownerIdSnap) {
+                          String? ownerId = ownerIdSnap.data;
+
+                          return Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Container(
+                              padding:
+                                  EdgeInsets.only(left: 16, right: 16, top: 8),
+                              alignment: Alignment.center,
+                              child: Row(
+                                children: [
+                                  Expanded(
+                                    child: Container(
+                                      alignment: Alignment.center,
+                                      child: Text("Alarm",
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .headline6),
+                                    ),
                                   ),
-                                ),
-                                if (_alarmChannel.ownerId == userId)
-                                  IconButton(
-                                    icon: Icon(Icons.add_alarm),
-                                    onPressed: () {
-                                      Future<TimeOfDay?> timeFuture =
-                                          showTimePicker(
-                                              context: context,
-                                              initialTime: TimeOfDay.now());
-                                      bloc.addNewVoteOption(
-                                          timeFuture, _alarmChannel);
-                                    },
-                                  ),
-                              ],
+                                  if (ownerId == userId)
+                                    IconButton(
+                                      icon: Icon(Icons.add_alarm),
+                                      onPressed: () {
+                                        Future<TimeOfDay?> timeFuture =
+                                            showTimePicker(
+                                                context: context,
+                                                initialTime: TimeOfDay.now());
+                                        bloc.addNewVoteOption(timeFuture);
+                                      },
+                                    ),
+                                ],
+                              ),
                             ),
-                          ),
-                          Container(
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                              children: [
-                                if (selection != null)
-                                  TextButton.icon(
-                                    style: ButtonStyle(
-                                        foregroundColor:
-                                            MaterialStateProperty.all(
-                                                Colors.white)),
-                                    icon: Icon(Icons.cancel),
-                                    label: Text("Opt out"),
-                                    onPressed: bloc.optOut,
-                                  )
-                              ],
+                            Container(
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                                children: [
+                                  if (selection != null)
+                                    TextButton.icon(
+                                      style: ButtonStyle(
+                                          foregroundColor:
+                                              MaterialStateProperty.all(
+                                                  Colors.white)),
+                                      icon: Icon(Icons.cancel),
+                                      label: Text("Opt out"),
+                                      onPressed: bloc.optOut,
+                                    )
+                                ],
+                              ),
                             ),
-                          ),
-                          for (AlarmOption option in snapshot.data ?? [])
-                            RadioListTile(
-                              groupValue: selection,
-                              title: Text(option.time.format(context)),
-                              subtitle: Text(option.dateTime.toString()),
-                              onChanged: (Timestamp? value) {
-                                if (value != null) bloc.vote(value);
-                              },
-                              secondary: Text(option.votes.toString()),
-                              value: option.timestamp,
-                            )
-                        ],
+                            for (AlarmOption option in snapshot.data ?? [])
+                              RadioListTile(
+                                groupValue: selection,
+                                title: Text(option.time.format(context)),
+                                subtitle: Text(option.dateTime.toString()),
+                                onChanged: (Timestamp? value) {
+                                  if (value != null) bloc.vote(value);
+                                },
+                                secondary: Text(option.votes.toString()),
+                                value: option.timestamp,
+                              )
+                          ],
+                        );
+                        },
                       );
                     },
                   );

--- a/lib/pages/shared-alarms/alarm-channel-page.dart
+++ b/lib/pages/shared-alarms/alarm-channel-page.dart
@@ -78,7 +78,7 @@ class _SubscribersBlock extends StatelessWidget {
           margin: EdgeInsets.all(8),
           padding: EdgeInsets.all(8),
           child: StreamBuilder(
-              stream: _alarmChannel.subscribers,
+              stream: bloc.subscribers,
               builder: (BuildContext context,
                   AsyncSnapshot<List<String?>> snapshot) {
                 final List<String?>? users = snapshot.data;

--- a/lib/pages/shared-alarms/alarm-channel-page.dart
+++ b/lib/pages/shared-alarms/alarm-channel-page.dart
@@ -12,16 +12,16 @@ import '../../widgets.dart';
 /// Radius of rounded edges of cards.
 const double _cardRadius = 16;
 
-/// Displays the details of an AlarmChannel given its AlarmChannelOverview.
+/// Displays the details of an alarm channel.
 class AlarmChannelPage extends StatelessWidget {
-  const AlarmChannelPage(this._alarmChannelOverview);
+  const AlarmChannelPage(this.alarmChannel);
 
-  final AlarmChannelOverview _alarmChannelOverview;
+  final AlarmChannel alarmChannel;
 
   @override
   Widget build(BuildContext context) {
     return Provider<AlarmChannelBloc>(
-      create: (BuildContext context) => AlarmChannelBloc(_alarmChannelOverview),
+      create: (BuildContext context) => AlarmChannelBloc(alarmChannel),
       child: Consumer<AlarmChannelBloc>(
         builder: (BuildContext context, AlarmChannelBloc bloc, _) => Scaffold(
           appBar: AppBar(

--- a/lib/pages/shared-alarms/alarm-channel-page.dart
+++ b/lib/pages/shared-alarms/alarm-channel-page.dart
@@ -179,7 +179,7 @@ class _AlarmBlock extends StatelessWidget {
                 builder: (BuildContext context,
                     AsyncSnapshot<List<AlarmOption>> snapshot) {
                   return StreamBuilder(
-                    stream: _alarmChannel.currentVote,
+                    stream: bloc.currentUserVote,
                     builder: (BuildContext context,
                         AsyncSnapshot<Timestamp?> voteSnapshot) {
                       Timestamp? selection = voteSnapshot.data;

--- a/lib/pages/shared-alarms/alarm-channel-page.dart
+++ b/lib/pages/shared-alarms/alarm-channel-page.dart
@@ -175,7 +175,7 @@ class _AlarmBlock extends StatelessWidget {
         builder: (BuildContext context, AlarmChannelBloc bloc, _) => Container(
               alignment: Alignment.centerLeft,
               child: StreamBuilder(
-                stream: _alarmChannel.alarmOptions,
+                stream: bloc.alarmOptions,
                 builder: (BuildContext context,
                     AsyncSnapshot<List<AlarmOption>> snapshot) {
                   return StreamBuilder(

--- a/lib/pages/shared-alarms/shared-alarms.dart
+++ b/lib/pages/shared-alarms/shared-alarms.dart
@@ -126,11 +126,11 @@ class SharedAlarmsPage extends StatelessWidget {
                 return UsernameForm();
               }
 
-              return StreamBuilder<List<AlarmChannelOverview>>(
+              return StreamBuilder<List<AlarmChannel>>(
                 stream: fbBloc.subscribedChannels,
                 builder:
                     (BuildContext context,
-                    AsyncSnapshot<List<AlarmChannelOverview>> subscribedChannelsSnap) {
+                    AsyncSnapshot<List<AlarmChannel>> subscribedChannelsSnap) {
                   return Scaffold(
                     appBar: AppBar(
                       backgroundColor: Theme.of(context).colorScheme.background,
@@ -169,19 +169,19 @@ class SharedAlarmsPage extends StatelessWidget {
 }
 
 class _SharedAlarmsListItem extends StatelessWidget {
-  const _SharedAlarmsListItem(this.alarmChannelOverview);
+  const _SharedAlarmsListItem(this.alarmChannel);
 
-  final AlarmChannelOverview alarmChannelOverview;
+  final AlarmChannel alarmChannel;
   static const double _cardRadius = 32;
 
   @override
   Widget build(BuildContext context) {
     return Consumer<SharedAlarmsBloc>(
       builder: (BuildContext context, SharedAlarmsBloc fbBloc, _) {
-        final Gradient? gradient = alarmChannelOverview.isActivated &&
-            alarmChannelOverview.currentAlarm != null
-            ? Gradients.getGradient(alarmChannelOverview.currentAlarm!.hour,
-            alarmChannelOverview.currentAlarm!.minute) : null;
+        final Gradient? gradient = alarmChannel.isActivated &&
+            alarmChannel.currentAlarm != null
+            ? Gradients.getGradient(alarmChannel.currentAlarm!.hour,
+            alarmChannel.currentAlarm!.minute) : null;
         Color? shadowColor = gradient?.colors[0].withValue(.5);
 
         return Container(
@@ -211,20 +211,20 @@ class _SharedAlarmsListItem extends StatelessWidget {
               onTap: () =>
                   Navigator.push(context, MaterialPageRoute(
                       builder: (context) =>
-                          AlarmChannelPage(alarmChannelOverview))),
+                          AlarmChannelPage(alarmChannel))),
               child: Container(
                 padding: EdgeInsets.only(
                     left: 24, right: 24, top: 32, bottom: 32),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(alarmChannelOverview.channelName ?? "<null>",
+                    Text(alarmChannel.channelName ?? "<null>",
                         style: Theme
                             .of(context)
                             .textTheme
                             .headline4),
-                    if (alarmChannelOverview.currentAlarm != null)
-                      Text(alarmChannelOverview.currentAlarm!.format(context),
+                    if (alarmChannel.currentAlarm != null)
+                      Text(alarmChannel.currentAlarm!.format(context),
                           style: Theme
                               .of(context)
                               .textTheme


### PR DESCRIPTION
Refactored shared alarms blocs to shift responsibilities to more logical places.

1. Moved all AlarmChannel properties to Streams in AlarmChannelBloc.
2. Removed AlarmChannel.
3. Renamed AlarmChannelOverview to be AlarmChannel.

This results in the ownerId and channelName being actively linked to Firestore, preparing for future updates allowing for ownership change and channel renaming with reactive updates.